### PR TITLE
fixed a crash with null value

### DIFF
--- a/source/Models/SuccessStory/Achievements.cs
+++ b/source/Models/SuccessStory/Achievements.cs
@@ -125,7 +125,7 @@ namespace LandingPage.Models.SuccessStory
                         }
                     }
                 }
-                return null;
+                return new Uri(@"/StartPagePlugin;component/star.png", UriKind.Relative);
             }
         }
 


### PR DESCRIPTION
Playnite crash with a null value for BitmapImage:
```01-02 14:42:27.747|ERROR|PlayniteApplication:Unhandled exception occured.
System.Windows.Markup.XamlParseException: L'initialisation de 'System.Windows.Media.Imaging.BitmapImage' a levé une exception. ---> System.InvalidOperationException: La propriété 'UriSource' ou la propriété 'StreamSource' doivent être définies.
   à System.Windows.Media.Imaging.BitmapImage.EndInit()
   à MS.Internal.Xaml.Runtime.ClrObjectRuntime.InitializationGuard(XamlType xamlType, Object obj, Boolean begin)```